### PR TITLE
Update octoprint_install.sh

### DIFF
--- a/octoprint_install.sh
+++ b/octoprint_install.sh
@@ -76,6 +76,7 @@ case $DISTRIBUTOR in
       curl \
       git \
       libyaml-dev \
+      libffi-dev \
       python3-dev \
       python3-pip \
       python3-setuptools \


### PR DESCRIPTION
Problem:
Collecting argon2-cffi-bindings (from argon2-cffi<22,>=21.3.0->octoprint)
  Downloading argon2-cffi-bindings-21.2.0.tar.gz (1.8 MB)
  Installing build dependencies ... error
  error: subprocess-exited-with-error
#include <ffi.h>
compilation terminated.

Fix: apt install libffi-dev